### PR TITLE
sync: arceos-org/linked_list => arceos-org/linked_list_r4l

### DIFF
--- a/sync_list.txt
+++ b/sync_list.txt
@@ -7,7 +7,7 @@ elliott10/lwext4_rust
 arceos-org/kspin
 arceos-org/axmm_crates
 arceos-org/percpu
-arceos-org/linked_list
+arceos-org/linked_list_r4l
 arceos-org/arceos-apps
 arceos-org/scheduler
 arceos-org/cpumask


### PR DESCRIPTION
![94b60799b3f8262a47adca050f6f07d](https://github.com/user-attachments/assets/725185f6-bb97-43a9-b391-344d264bd00c)

![a9dc7f703cb20f632c28e4c3b8323c0](https://github.com/user-attachments/assets/aea7680a-08a5-42b6-aed4-976c2da04de7)


 kern-crates 的 sync 出现新的问题了，出现一堆 linked_list_r4l 仓库，看起来是因为 sync_list 中的 arceos-org/linked_list ( https://github.com/arceos-org/linked_list ) 重命名了 linked_list_r4l。

感觉就是 arceos-org/linked_list 重命名成了 linked_list_r4l，然后有个地方根据新的 linked_list_r4l 来 fork，发现 kern-crates 已存在这个仓库，就新创建了 linked_list_r4l-n。

应该只要把 sync_list 里的arceos-org/linked_list改成 arceos-org/linked_list_r4l 就行了吧，然后把重复的 linked_list_r4l-n 删掉。

---

我已经把 kern-crates/linked_list_r4l 的 20 多个重复仓库删掉了。

