### PR TITLE
refactor: 重写 sync, fork 和生成 repo list 的逻辑 （2）

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
+  permissions: write-all
   run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -5,7 +5,7 @@ on:
   #   - cron: '0 0 * * *'
   push:
     branches:
-      - refactor
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -8,8 +8,9 @@ on:
       - refactor
   workflow_dispatch:
 
+permissions: write-all
+
 jobs:
-  permissions: write-all
   run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -8,8 +8,6 @@ on:
       - refactor
   workflow_dispatch:
 
-permissions: write-all
-
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -19,7 +17,7 @@ jobs:
         run: cd task && npm install && npm run start
         env:
           # GH_TOKEN: ${{ secrets.GH_CLI_TOKEN }}
-          # GH_TOKEN: ${{ github.token }}
+          # GH_TOKEN: ${{ github.token }} # this throws an error even with write-all permissions
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           FORCE_COLOR: 3
           TEST: true

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,7 +19,8 @@ jobs:
         run: cd task && npm install && npm run start
         env:
           # GH_TOKEN: ${{ secrets.GH_CLI_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
+          # GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           FORCE_COLOR: 3
           TEST: true
           EXECUTE: true

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Run index.ts
         run: cd task && npm install && npm run start && ls -alh
         env:
-          # GH_TOKEN: ${{ secrets.GH_CLI_TOKEN }}
-          # GH_TOKEN: ${{ github.token }} # this throws an error even with write-all permissions
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           FORCE_COLOR: 3
-          TEST: true
+          TEST: false
           EXECUTE: true

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run index.ts
-        run: cd task && npm install && npm run start
+        run: cd task && npm install && npm run start && ls -alh
         env:
           # GH_TOKEN: ${{ secrets.GH_CLI_TOKEN }}
           # GH_TOKEN: ${{ github.token }} # this throws an error even with write-all permissions

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/node_modules
+**/repo_list.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/node_modules
 **/repo_list.json
+**/repo_list_raw.json

--- a/task/mod/index.ts
+++ b/task/mod/index.ts
@@ -30,7 +30,7 @@ async function main() {
   const owned_repos = gen_owned_repos(owner, repositoryOwner);
 
   const repo_list = sync_or_fork(sync_list, owned_repos, owner);
-  log("repo_list.length =", repo_list.length);
+  log("\nrepo_list.length =", repo_list.length);
   await writeFile("repo_list.json", JSON.stringify(repo_list, null, 2));
   await writeFile("repo_list_raw.json", JSON.stringify({ sync_list, owner, owned_repos }, null, 2));
 

--- a/task/mod/index.ts
+++ b/task/mod/index.ts
@@ -3,6 +3,7 @@ import { log } from "node:console";
 import * as query from "./query.ts";
 import { read_sync_list } from "./sync_list.ts";
 import { gen_owned_repos, sync_or_fork } from "./types.ts";
+import { writeFile } from "node:fs/promises";
 
 async function main() {
 
@@ -28,7 +29,9 @@ async function main() {
 
   const owned_repos = gen_owned_repos(owner, repositoryOwner);
 
-  sync_or_fork(sync_list, owned_repos, owner);
+  const repo_list = sync_or_fork(sync_list, owned_repos, owner);
+  log("repo_list.length =", repo_list.length);
+  await writeFile("repo_list.json", JSON.stringify(repo_list));
 
 }
 

--- a/task/mod/index.ts
+++ b/task/mod/index.ts
@@ -1,10 +1,8 @@
 import { Octokit } from "octokit";
-import chalk from 'chalk';
 import { log } from "node:console";
 import * as query from "./query.ts";
 import { read_sync_list } from "./sync_list.ts";
-import type { UserRepo, OwnedRepo } from "./types.ts";
-import { exec, ExecException } from "node:child_process";
+import { gen_owned_repos, sync_or_fork } from "./types.ts";
 
 async function main() {
 
@@ -36,71 +34,6 @@ async function main() {
 
   sync_or_fork(sync_list, owned_repos, owner);
 
-}
-
-function gen_owned_repos(owner: string, repos: query.RepositoryOwner): OwnedRepo[] {
-  return repos.repositories.nodes.map(repo => {
-    const owned = { user: owner, repo: repo.name };
-    const non_owned = repo.parent && { user: repo.parent.owner.login, repo: repo.parent.name };
-    return { owned, non_owned }
-  });
-}
-
-/**
- * any non_owned matches against repo_in_sync_list => need syncing
- * all non_owned don't match against repo_in_sync_list: UserRepo => need forking
- */
-function sync_or_fork(sync_list: UserRepo[], owned_repos: OwnedRepo[], owner: string) {
-  const non_onwed = owned_repos.map(val => val.non_owned);
-
-  for (const outer of sync_list) {
-    const pos = non_onwed.findIndex(val => val?.user === outer.user && val.repo === outer.repo);
-    if (pos === -1) {
-      // need forking
-      do_fork(owner, outer);
-    } else {
-      // need syncing
-      do_sync(owned_repos[pos].owned);
-    }
-  }
-}
-
-function do_sync(owned: UserRepo) {
-  // Sync remote fork from its parent
-  // src: https://cli.github.com/manual/gh_repo_sync
-  const cmd = `gh repo sync ${owned.user}/${owned.repo}`;
-  do_(cmd);
-}
-
-function do_fork(owner: string, outer: UserRepo) {
-  // gh repo fork non_owned --org kern-crates --default-branch-only
-  // src: https://cli.github.com/manual/gh_repo_fork
-  const cmd = `gh repo fork ${outer.user}/${outer.repo} --org ${owner} --default-branch-only`;
-  do_(cmd);
-}
-
-function do_(cmd: string) {
-  console.time(cmd);
-  if (process.env.EXECUTE === "true") {
-    log(chalk.yellow(`[real exec] ${cmd}`));
-    exec(cmd, (error, stdout, stderr) => handleExecOutput(cmd, error, stdout, stderr));
-  } else {
-    log(chalk.gray(`[fake exec] ${cmd}`));
-  }
-  console.timeEnd(cmd);
-}
-
-function handleExecOutput(cmd: string, error: ExecException | null, stdout: string, stderr: string) {
-  // gh CLI writes data to TTY but not to pipe, so even if we get output from terminal,
-  // nothing is captured in the callba the callback.
-  // See https://stackoverflow.com/questions/72731726/how-do-i-capture-output-of-the-following-command-gh-workflow-run-id
-  // and https://stackoverflow.com/questions/78316928/gh-has-different-output-when-captured-with-python-subprocess-run
-  if (stdout) { log(`${cmd} [stdout]: ${stdout}`); }
-  if (error) {
-    console.error(chalk.bgRed(`${cmd} 执行出错:\n`) + chalk.red(`${stderr}`));
-  } else if (stderr) {
-    console.error(`${cmd} [stderr]: ${stderr}`);
-  }
 }
 
 main().then(() => log("Main thread done.")).catch(err => console.error(err));

--- a/task/mod/index.ts
+++ b/task/mod/index.ts
@@ -31,7 +31,8 @@ async function main() {
 
   const repo_list = sync_or_fork(sync_list, owned_repos, owner);
   log("repo_list.length =", repo_list.length);
-  await writeFile("repo_list.json", JSON.stringify(repo_list));
+  await writeFile("repo_list.json", JSON.stringify(repo_list, null, 2));
+  await writeFile("repo_list_raw.json", JSON.stringify({ sync_list, owner, owned_repos }, null, 2));
 
 }
 

--- a/task/mod/index.ts
+++ b/task/mod/index.ts
@@ -15,13 +15,9 @@ async function main() {
     viewer: { login },
   } = await octokit.graphql<{
     viewer: { login: string }
-  }>(`{
-  viewer {
-    login
-  }
-}`);
+  }>(`{ viewer { login } }`);
 
-  log(login);
+  log("login:", login);
 
   const owner = "kern-crates";
   const { repositoryOwner } = await octokit.graphql.paginate<query.Repos>(

--- a/task/mod/index.ts
+++ b/task/mod/index.ts
@@ -91,11 +91,15 @@ function do_(cmd: string) {
 }
 
 function handleExecOutput(cmd: string, error: ExecException | null, stdout: string, stderr: string) {
+  // gh CLI writes data to TTY but not to pipe, so even if we get output from terminal,
+  // nothing is captured in the callba the callback.
+  // See https://stackoverflow.com/questions/72731726/how-do-i-capture-output-of-the-following-command-gh-workflow-run-id
+  // and https://stackoverflow.com/questions/78316928/gh-has-different-output-when-captured-with-python-subprocess-run
   if (stdout) { log(`${cmd} [stdout]: ${stdout}`); }
-  // if (stderr) { console.error(`${cmd} stderr: ${stderr}`); }
   if (error) {
     console.error(chalk.bgRed(`${cmd} 执行出错:\n`) + chalk.red(`${stderr}`));
-    return;
+  } else if (stderr) {
+    console.error(`${cmd} [stderr]: ${stderr}`);
   }
 }
 

--- a/task/mod/types.ts
+++ b/task/mod/types.ts
@@ -92,7 +92,8 @@ function do_(cmd: string) {
     log(chalk.yellow(`\n[real exec] ${cmd}`));
 
     try {
-      execSync(cmd, { stdio: 'inherit' });
+      const buffer = execSync(cmd, { stdio: 'inherit' });
+      log(buffer);
     } catch (error) {
       success = false;
       let err: any = error;

--- a/task/mod/types.ts
+++ b/task/mod/types.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { log } from "node:console";
 import * as query from "./query.ts";
-import { exec, ExecException } from "node:child_process";
+import { execSync } from "node:child_process";
 
 export type UserRepo = {
   user: string,
@@ -80,35 +80,31 @@ function do_fork(owner: string, outer: UserRepo) {
   return do_(cmd);
 }
 
+// gh CLI writes data to TTY but not to pipe, so even if we get output from terminal,
+// nothing is captured in the callback.
+//
+// But we can use inherit stdio to capture the gh output.
 function do_(cmd: string) {
   let success = true;
   console.time(cmd);
 
   if (process.env.EXECUTE === "true") {
-    log(chalk.yellow(`[real exec] ${cmd}`));
+    log(chalk.yellow(`\n[real exec] ${cmd}`));
 
-    const child = exec(cmd, (error, stdout, stderr) => handleExecOutput(cmd, error, stdout, stderr));
-
-    if (child.exitCode === null) {
-      log(cmd, ": is still running");
+    try {
+      execSync(cmd, { stdio: 'inherit' });
+    } catch (error) {
       success = false;
-    } else if (child.exitCode !== 0) {
-      log(cmd, ": exited with", child.exitCode);
-      success = false;
+      let err: any = error;
+      handleExecOutput(cmd, err, err.stdout, err.stderr);
     }
-  } else {
-    log(chalk.gray(`[fake exec] ${cmd}`));
-  }
 
-  console.timeEnd(cmd);
-  return success;
+    console.timeEnd(cmd);
+    return success;
+  }
 }
 
-function handleExecOutput(cmd: string, error: ExecException | null, stdout: string, stderr: string) {
-  // gh CLI writes data to TTY but not to pipe, so even if we get output from terminal,
-  // nothing is captured in the callba the callback.
-  // See https://stackoverflow.com/questions/72731726/how-do-i-capture-output-of-the-following-command-gh-workflow-run-id
-  // and https://stackoverflow.com/questions/78316928/gh-has-different-output-when-captured-with-python-subprocess-run
+function handleExecOutput(cmd: string, error: any, stdout: string, stderr: string) {
   if (stdout) { log(`${cmd} [stdout]: ${stdout}`); }
   if (error) {
     console.error(chalk.bgRed(`${cmd} 执行出错:\n`) + chalk.red(`${stderr}`));
@@ -116,3 +112,4 @@ function handleExecOutput(cmd: string, error: ExecException | null, stdout: stri
     console.error(`${cmd} [stderr]: ${stderr}`);
   }
 }
+

--- a/task/mod/types.ts
+++ b/task/mod/types.ts
@@ -1,3 +1,7 @@
+import chalk from 'chalk';
+import { log } from "node:console";
+import * as query from "./query.ts";
+import { exec, ExecException } from "node:child_process";
 
 export type UserRepo = {
   user: string,
@@ -9,3 +13,67 @@ export type OwnedRepo = {
   non_owned: null | UserRepo,
 }
 
+export function gen_owned_repos(owner: string, repos: query.RepositoryOwner): OwnedRepo[] {
+  return repos.repositories.nodes.map(repo => {
+    const owned = { user: owner, repo: repo.name };
+    const non_owned = repo.parent && { user: repo.parent.owner.login, repo: repo.parent.name };
+    return { owned, non_owned }
+  });
+}
+
+/**
+ * any non_owned matches against repo_in_sync_list => need syncing
+ * all non_owned don't match against repo_in_sync_list: UserRepo => need forking
+ */
+export function sync_or_fork(sync_list: UserRepo[], owned_repos: OwnedRepo[], owner: string) {
+  const non_onwed = owned_repos.map(val => val.non_owned);
+
+  for (const outer of sync_list) {
+    const pos = non_onwed.findIndex(val => val?.user === outer.user && val.repo === outer.repo);
+    if (pos === -1) {
+      // need forking
+      do_fork(owner, outer);
+    } else {
+      // need syncing
+      do_sync(owned_repos[pos].owned);
+    }
+  }
+}
+
+function do_sync(owned: UserRepo) {
+  // Sync remote fork from its parent
+  // src: https://cli.github.com/manual/gh_repo_sync
+  const cmd = `gh repo sync ${owned.user}/${owned.repo}`;
+  do_(cmd);
+}
+
+function do_fork(owner: string, outer: UserRepo) {
+  // gh repo fork non_owned --org kern-crates --default-branch-only
+  // src: https://cli.github.com/manual/gh_repo_fork
+  const cmd = `gh repo fork ${outer.user}/${outer.repo} --org ${owner} --default-branch-only`;
+  do_(cmd);
+}
+
+function do_(cmd: string) {
+  console.time(cmd);
+  if (process.env.EXECUTE === "true") {
+    log(chalk.yellow(`[real exec] ${cmd}`));
+    exec(cmd, (error, stdout, stderr) => handleExecOutput(cmd, error, stdout, stderr));
+  } else {
+    log(chalk.gray(`[fake exec] ${cmd}`));
+  }
+  console.timeEnd(cmd);
+}
+
+function handleExecOutput(cmd: string, error: ExecException | null, stdout: string, stderr: string) {
+  // gh CLI writes data to TTY but not to pipe, so even if we get output from terminal,
+  // nothing is captured in the callba the callback.
+  // See https://stackoverflow.com/questions/72731726/how-do-i-capture-output-of-the-following-command-gh-workflow-run-id
+  // and https://stackoverflow.com/questions/78316928/gh-has-different-output-when-captured-with-python-subprocess-run
+  if (stdout) { log(`${cmd} [stdout]: ${stdout}`); }
+  if (error) {
+    console.error(chalk.bgRed(`${cmd} 执行出错:\n`) + chalk.red(`${stderr}`));
+  } else if (stderr) {
+    console.error(`${cmd} [stderr]: ${stderr}`);
+  }
+}

--- a/task/mod/types.ts
+++ b/task/mod/types.ts
@@ -92,8 +92,7 @@ function do_(cmd: string) {
     log(chalk.yellow(`\n[real exec] ${cmd}`));
 
     try {
-      const buffer = execSync(cmd, { stdio: 'inherit' });
-      log(buffer);
+      execSync(cmd, { stdio: 'inherit' });
     } catch (error) {
       success = false;
       let err: any = error;

--- a/task/tsconfig.json
+++ b/task/tsconfig.json
@@ -60,7 +60,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    "noEmit": true, /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */


### PR DESCRIPTION
* 创建新的 GH_TOKEN 
* 将仓库列表数据写入 repo_list.json 和 repo_list_raw.json
* 把异步的 exec 替换成同步的 execSync，同步处理调用 gh fork/sync 的结果