### PR TITLE
fix: force sync in case parent repo diverges

### DIFF
--- a/task/src/gh.ts
+++ b/task/src/gh.ts
@@ -88,7 +88,7 @@ export function gen_output(repos: string[], owned_repos: OwnedRepo[], exclude_li
 function do_sync(owned: UserRepo, target: string) {
   // Sync remote fork from its parent
   // src: https://cli.github.com/manual/gh_repo_sync
-  const cmd = `gh repo sync ${owned.user}/${owned.repo}`;
+  const cmd = `gh repo sync ${owned.user}/${owned.repo} --force`;
   return do_(cmd, target);
 }
 


### PR DESCRIPTION
当父仓库强制推送导致提交分叉，需要强制覆盖进行同步。

```bash
[real exec] [Starry-OS/Starry-New] gh repo sync kern-crates/Starry-New 
can't sync because there are diverging changes; use `--force` to overwrite the destination branch
```