### PR TITLE
chore(templates/.github/workflows/ci.yml): detect clippy::new_without_default

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Check code format
       run: cargo fmt --all -- --check
     - name: Clippy
-      run: cargo clippy --target ${{ matrix.targets }} --all-features -- -A clippy::new_without_default
+      run: cargo clippy --target ${{ matrix.targets }} --all-features
     - name: Build
       run: cargo build --target ${{ matrix.targets }} --all-features
     - name: Unit test


### PR DESCRIPTION

Authors should explicitly handle clippy::new_without_default diagnostics via:
* allowing the lint `#[allow(clippy::new_without_default)]`
* or adding a Default trait impl as the lint suggests