### PR TITLE
add embassy-priority, rust-sel4, and e1000e-frame to exclude_list

### DIFF
--- a/exclude_list.txt
+++ b/exclude_list.txt
@@ -6,3 +6,6 @@ kern-crates/kern-crates.github.io
 rcore-os/libc-test
 os-checker/docs
 os-checker/os-checker.github.io
+AsyncModules/embassy-priority
+qclic/e1000e-frame
+seL4/rust-sel4


### PR DESCRIPTION
They will still be synced in kern-crates org, but just not emitted to repo_list.json or os-checker_config.json.

Checking them is is time-consuming and needs large storage space which github runner machines are unable to meet.