### PR TITLE
feat: add maintain_list to include forked repos with HEAD diverging

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
 
 env:

--- a/maintain_list.txt
+++ b/maintain_list.txt
@@ -1,0 +1,1 @@
+rcore-os/rboot

--- a/task/src/gh.ts
+++ b/task/src/gh.ts
@@ -35,13 +35,13 @@ export function sync(repos: OwnedRepo[]) {
     // skip owned repos
     if (repo.non_owned === null) continue;
 
-    const parent_name = to_string(repo.non_owned);
-    if (do_sync(repo.owned, parent_name)) {
-      log(`${parent_name} synced.`);
-    } else if (maintain.has(parent_name)) {
-      log(`${parent_name} is not synced, but maintained by kern-crates.`);
+    const parent = to_string(repo.non_owned);
+    if (do_sync(repo.owned, parent)) {
+      log(`${parent} synced.`);
+    } else if (maintain.has(parent)) {
+      log(`${parent} is not synced, but maintained by kern-crates.`);
     } else {
-      throw_err(`${parent_name} is not synced.`);
+      throw_err(`${parent} is not synced.`);
     }
   }
 }

--- a/task/src/gh.ts
+++ b/task/src/gh.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { log } from "console";
 import { execSync } from "child_process";
 import { OwnedRepo, UserRepo, to_string } from "./types.ts";
+import { read_maintain_list } from "./read_list.ts";
 
 export type Output = {
   repo_list: string[],
@@ -26,15 +27,21 @@ export function fork(fork_list: UserRepo[], non_owned: Set<string>, org: string)
 
 // Sync all non_onwed repos.
 export function sync(repos: OwnedRepo[]) {
+  // Repos that are forked to kern-crates as well as modified in kern-crates, 
+  // especially with HEAD diverging from parent repos.
+  const maintain = read_maintain_list();
+
   for (const repo of repos) {
     // skip owned repos
     if (repo.non_owned === null) continue;
 
-    const repo_name = to_string(repo.non_owned);
-    if (do_sync(repo.owned, repo_name)) {
-      log(`${repo_name} synced.`);
+    const parent_name = to_string(repo.non_owned);
+    if (do_sync(repo.owned, parent_name)) {
+      log(`${parent_name} synced.`);
+    } else if (maintain.has(parent_name)) {
+      log(`${parent_name} is not synced, but maintained by kern-crates.`);
     } else {
-      throw_err(`${repo_name} is not synced.`);
+      throw_err(`${parent_name} is not synced.`);
     }
   }
 }

--- a/task/src/read_list.ts
+++ b/task/src/read_list.ts
@@ -1,4 +1,4 @@
-import { type UserRepo } from "./types.ts";
+import { to_string, type UserRepo } from "./types.ts";
 import { readFileSync } from "node:fs";
 
 /** 
@@ -24,7 +24,7 @@ function read_list(path: string): UserRepo[] {
     const [user, repo] = line.split("/").map(word => word.trim());
     if (!user) { throw new Error(`No user in \`${line}\`.`); }
     if (!repo) { throw new Error(`No repo in \`${line}\`.`); }
-    return { user, repo };
+    return { user, repo, isArchived: false };
   }).sort(cmp);
 }
 
@@ -34,4 +34,8 @@ export function read_fork_list(): UserRepo[] {
 
 export function read_exclude_list(): UserRepo[] {
   return read_list("../exclude_list.txt");
+}
+
+export function read_maintain_list(): Set<string> {
+  return new Set(read_list("../maintain_list.txt").map(to_string));
 }

--- a/task/src/read_list.ts
+++ b/task/src/read_list.ts
@@ -24,7 +24,7 @@ function read_list(path: string): UserRepo[] {
     const [user, repo] = line.split("/").map(word => word.trim());
     if (!user) { throw new Error(`No user in \`${line}\`.`); }
     if (!repo) { throw new Error(`No repo in \`${line}\`.`); }
-    return { user, repo, isArchived: false };
+    return { user, repo };
   }).sort(cmp);
 }
 

--- a/task/src/types.ts
+++ b/task/src/types.ts
@@ -4,7 +4,7 @@ import * as query from "./query.ts";
 export type UserRepo = {
   user: string,
   repo: string,
-  isArchived: boolean,
+  isArchived?: boolean,
 }
 
 export type OwnedRepo = {


### PR DESCRIPTION
https://github.com/kern-crates/rboot 的最新提交和 parent repo 的最新提交具有不同的 HEAD，那么调用 gh repo sync 失败。
直接在 kern-crates 组织 forked 的仓库上提交新的代码，意味着 kern-crates 不再是纯粹的镜像角色。

![4cfbff04729292078928434b8046be1](https://github.com/user-attachments/assets/04eddb2a-3a12-4d20-a61c-078e8851da49)

![3758e71952a2e3874feca842c13cb03](https://github.com/user-attachments/assets/3f802df0-ac8b-44fe-96c7-715ff28631a8)


因此，建立新的 maintaining_list.txt 文件，把 rcore-os/rboot 放进去，在调用 sync 时排除它。

这意味着 maintain_list 记录 kern-crates 组织维护 forked 仓库的操作。