### PR TITLE
fix(gh): don't sync if parent is archived

### DIFF
--- a/task/src/gh.ts
+++ b/task/src/gh.ts
@@ -31,8 +31,8 @@ export function sync(repos: OwnedRepo[]) {
   const maintain = read_maintain_list();
 
   for (const repo of repos) {
-    // skip owned repos
-    if (repo.non_owned === null) continue;
+    // skip owned repos or archived repo
+    if (repo.non_owned === null || repo.non_owned.isArchived === true) continue;
 
     const parent = to_string(repo.non_owned);
     if (do_sync(repo.owned, parent)) {


### PR DESCRIPTION
close https://github.com/kern-crates/.github/issues/41

```
$ gh repo sync kern-crates/memory_set
HTTP 403: Repository was archived so is read-only. (https://api.github.com/repos/kern-crates/memory_set/merge-upstream)
```