### PR TITLE
fix: 恢复 https://github.com/kern-crates 主页 README，但通过符号链接

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
https://github.com/kern-crates/.github/pull/43 删除了多余的 profile/README.md 文件，这导致 github 组织页面缺少 README。

此 PR 恢复 kern-crates 组织页面的 README，但通过符号链接而不是复制文件。