### PR TITLE
update(templates/ci.yml): install cargo-{binutils,hack}; cargo hack --each-feature

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
       matrix:
         rust-toolchain: [nightly]
         targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat]
-        features: ["--all-features"]
-        # features: ["", "--all-features"] # default features or all features
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@v2
@@ -28,9 +26,9 @@ jobs:
     - name: Check code format
       run: cargo fmt --all -- --check
     - name: Clippy
-      run: cargo clippy --target ${{ matrix.targets }} ${{ matrix.features }} -- -D warnings
+      run: cargo hack clippy --target ${{ matrix.targets }} --each-feature -- -D warnings
     - name: Build
-      run: cargo build --target ${{ matrix.targets }} ${{ matrix.features }}
+      run: cargo hack build --target ${{ matrix.targets }} --each-feature
     - name: Unit test
       if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' }}
-      run: cargo test --target ${{ matrix.targets }} ${{ matrix.features }} -- --nocapture
+      run: cargo hack test --target ${{ matrix.targets }} --each-feature -- --nocapture

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Check code format
       run: cargo fmt --all -- --check
     - name: Clippy
-      run: cargo hack clippy --target ${{ matrix.targets }} --each-feature -- -D warnings
+      run: cargo hack clippy --target ${{ matrix.targets }} --each-feature --no-dev-deps -- -D warnings
     - name: Build
-      run: cargo hack build --target ${{ matrix.targets }} --each-feature
+      run: cargo hack build --target ${{ matrix.targets }} --each-feature --no-dev-deps
     - name: Unit test
       if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' }}
-      run: cargo hack test --target ${{ matrix.targets }} --each-feature -- --nocapture
+      run: cargo hack test --target ${{ matrix.targets }} --each-feature --no-dev-deps -- --nocapture

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
         # features: ["", "--all-features"] # default features or all features
     steps:
     - uses: actions/checkout@v4
+    - uses: taiki-e/install-action@v2
+      with:
+        # Add more tools that can be install from their github release assets (via cargo-binstall)
+        tool: cargo-hack,cargo-binutils
     - uses: dtolnay/rust-toolchain@nightly
       with:
         toolchain: ${{ matrix.rust-toolchain }}


### PR DESCRIPTION
* cargo-binutils is commonly used for OS packages
  * the installation is done via cargo-binstall
* [`cargo hack --each-feature --no-dev-deps`](https://github.com/taiki-e/cargo-hack) performs a cargo subcommand multiple time for each cargo non-dep feature