### PR TITLE
添加 drivercraft 组织的 rdrive 和 CrabUSB

### DIFF
--- a/fork_list.txt
+++ b/fork_list.txt
@@ -7,7 +7,6 @@ Starry-OS/Starry-Old
 ZR233/arm-gic-driver
 ZR233/arm-pl011-rs
 ZR233/ostool
-ZR233/rdrive
 arceos-hypervisor/arm_vcpu
 arceos-hypervisor/arm_vgic
 arceos-hypervisor/axaddrspace
@@ -46,6 +45,7 @@ arceos-org/percpu
 arceos-org/scheduler
 arceos-org/starry-next
 arceos-org/timer_list
+drivercraft/rdrive
 elliott10/e1000-driver
 elliott10/lwext4_rust
 guoweikang/osl

--- a/fork_list.txt
+++ b/fork_list.txt
@@ -45,6 +45,7 @@ arceos-org/percpu
 arceos-org/scheduler
 arceos-org/starry-next
 arceos-org/timer_list
+drivercraft/CrabUSB
 drivercraft/rdrive
 elliott10/e1000-driver
 elliott10/lwext4_rust


### PR DESCRIPTION
* ZR233/rdrive 转移至 drivercraft/rdrive
* drivercraft/CrabUSB 是用 Rust 实现的 USB-Host 驱动