### PR TITLE
add `KMSorSMS/embassy_preempt`

### DIFF
--- a/exclude_list.txt
+++ b/exclude_list.txt
@@ -7,5 +7,6 @@ rcore-os/libc-test
 os-checker/docs
 os-checker/os-checker.github.io
 AsyncModules/embassy-priority
+KMSorSMS/embassy_preempt
 qclic/e1000e-frame
 seL4/rust-sel4

--- a/fork_list.txt
+++ b/fork_list.txt
@@ -3,6 +3,7 @@ Azure-stars/kernel_elf_parser
 Byte-OS/ByteOS
 Byte-OS/lose-net-stack
 Byte-OS/polyhal
+KMSorSMS/embassy_preempt
 Starry-OS/Starry-Old
 ZR233/arm-gic-driver
 ZR233/arm-pl011-rs


### PR DESCRIPTION
添加 `embassy_preempt`，它是基于 embassy 的抢占式调度库。

doc: https://kmsorsms.github.io/embassy_preempt


由于目前在 Github CI 机器上无法检查完整的  embassy 仓库，所以把它放入 exclude_list：不要在 os-checker 所需的 JSON 清单中包含它。