### PR TITLE
Feat: add `drivercraft/driver-crates` submodule; fix CI by updating submodules to upstream

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -45,6 +45,11 @@ jobs:
           ls -alh starry-crates
           ls -alh axvisor-crates
 
+      - name: Update submodules
+        run: |
+          cd ~/.github
+          git submodule foreach 'git checkout main && git pull origin main'
+
       - name: Update refined_list
         run: cd ~/.github/crates && ./refined_list.sh
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "crates/axvisor-crates"]
 	path = crates/axvisor-crates
 	url = https://github.com/arceos-hypervisor/axvisor-crates
+[submodule "crates/driver-crates"]
+	path = crates/driver-crates
+	url = https://github.com/drivercraft/driver-crates.git

--- a/crates/refined_list.sh
+++ b/crates/refined_list.sh
@@ -1,3 +1,6 @@
+# Avoid inconsistent collation order
+export LC_ALL=C
+
 # Extract user/repo from .gitmodules
 cat arceos-crates/.gitmodules starry-crates/.gitmodules axvisor-crates/.gitmodules |
   grep -oP 'url = https:\/\/github\.com\/\K([^\/]+\/[^\/]+)(?=\.git)' |

--- a/crates/refined_list.sh
+++ b/crates/refined_list.sh
@@ -2,6 +2,6 @@
 export LC_ALL=C
 
 # Extract user/repo from .gitmodules
-cat arceos-crates/.gitmodules starry-crates/.gitmodules axvisor-crates/.gitmodules |
-  grep -oP 'url = https:\/\/github\.com\/\K([^\/]+\/[^\/]+)(?=\.git)' |
+cat arceos-crates/.gitmodules starry-crates/.gitmodules axvisor-crates/.gitmodules driver-crates/.gitmodules |
+  grep -oP 'url = https:\/\/github\.com\/\K([^\/]+\/[^\/]+?)(?=\.git|\/|$)' |
   sort | uniq >refined_list.txt

--- a/crates/refined_list.txt
+++ b/crates/refined_list.txt
@@ -4,6 +4,7 @@ Starry-Mix-THU/axptr
 Starry-Mix-THU/axsignal
 Starry-Mix-THU/extern-trait
 Starry-Mix-THU/weak-map
+ZR233/ostool
 arceos-hypervisor/arm_gicv2
 arceos-hypervisor/arm_vcpu
 arceos-hypervisor/arm_vgic
@@ -44,3 +45,16 @@ arceos-org/slab_allocator
 arceos-org/timer_list
 arceos-org/tuple_for_each
 arceos-org/x86_rtc
+bullhh/igb_driver
+drivercraft/CrabUSB
+drivercraft/aarch64-cpu-ext
+drivercraft/dma-api
+drivercraft/fdt-parser
+drivercraft/mbarrier
+drivercraft/nvme
+drivercraft/pcie
+drivercraft/rdrive
+qclic/phytium-mci
+rcore-os/any-uart
+rcore-os/arm-gic-driver
+rcore-os/serial-async


### PR DESCRIPTION
This PR
* adds repos list from `drivercraft/driver-crates` to refined_list.txt
* fixes regex expression to match repos ending with or without `.git`
* fixes CI by updating submodules to upstream before generating refined_list.txt